### PR TITLE
Date-time format change, city + country fields

### DIFF
--- a/app/views/campaigns/email.erb
+++ b/app/views/campaigns/email.erb
@@ -16,6 +16,7 @@
       <%= f.text_block :from_name, :div_class => '', :label_class => '', :placeholder => Email.human_attribute_name(:from_name) %>
       <%= f.email_block :from_email, :div_class => '', :label_class => '', :placeholder => Email.human_attribute_name(:from_email) %>
       <%= f.text_block :from_address1, :div_class => '', :label_class => '', :placeholder => Email.human_attribute_name(:from_address1) %>
+      <%= f.text_block :from_city, :div_class => '', :label_class => '', :placeholder => Email.human_attribute_name(:from_city) %>
       <%= f.text_block :from_postcode, :div_class => '', :label_class => '', :placeholder => Email.human_attribute_name(:from_postcode) %>
       <%= f.submit_block button_text: 'Send', :div_class => '' %>
     <% end %>

--- a/lib/date_formats.rb
+++ b/lib/date_formats.rb
@@ -1,11 +1,11 @@
 require 'active_support/core_ext/integer/inflections'
 
 Time::DATE_FORMATS.merge!(
-  :default => lambda { |time| time.to_s(:date) + ', ' + time.to_s(:time) },
+  :default => lambda { |time| time.to_s(:date) + ' ' + time.to_s(:time) },
   :date => lambda { |time| time.to_date.to_s },
-  :time => lambda { |time| time.strftime("#{(t = time.hour%12) == 0 ? 12 : t}:%M#{time.strftime('%p').downcase}") }
+  :time => lambda { |time| time.strftime("%H:%M:%S") }
 )
 
 Date::DATE_FORMATS.merge!(
-  :default => lambda { |date| date.strftime("%a #{date.day.ordinalize} %b %Y") }
+  :default => lambda { |date| date.strftime("%d/%m/%Y") }
 )

--- a/models/email.rb
+++ b/models/email.rb
@@ -7,12 +7,14 @@ class Email
   field :from_name, :type => String  
   field :from_email, :type => String
   field :from_address1, :type => String
+  field :from_city, :type => String
   field :from_postcode, :type => String
+  field :from_country, :type => String, default: 'United Kingdom'
   field :message_id, :type => String
   
   belongs_to :decision
   
-  validates_presence_of :subject, :body, :from_name, :from_email, :from_address1, :from_postcode, :decision
+  validates_presence_of :subject, :body, :from_name, :from_email, :from_address1, :from_city, :from_postcode, :decision
         
   def self.admin_fields
     {
@@ -21,7 +23,9 @@ class Email
       :from_name => :text,
       :from_email => :email,
       :from_address1 => :text,
+      :from_city => :text,
       :from_postcode => :text,
+      :from_country => :text,
       :message_id => :text,
       :decision_id => :lookup      
     }
@@ -32,7 +36,9 @@ class Email
       :from_name => 'Your name',
       :from_email => 'Your email address',
       :from_address1 => 'First line of address',
+      :from_city => 'Your city',
       :from_postcode => 'Your postcode',
+      :from_country => 'Country',
     }[attr.to_sym] || super  
   end   
   
@@ -63,7 +69,7 @@ class Email
   def post_user_info
     if ENV['POST_ENDPOINT']
       agent = Mechanize.new
-      agent.post ENV['POST_ENDPOINT'], {account: {name: from_name, email: from_email, postcode: from_postcode, source: "#{ENV['DOMAIN']}:#{decision.campaign.slug}"}}
+      agent.post ENV['POST_ENDPOINT'], {account: {name: from_name, email: from_email, city: from_city, postcode: from_postcode, country: from_country, source: "#{ENV['DOMAIN']}:#{decision.campaign.slug}"}}
     end
   end
   


### PR DESCRIPTION
Change date-time format from 'Mon 1st Jan, 12pm' to '01/01/2017 00:00:00'
Add City and Country (auto-recorded as UK) fields to email model
Add City form field for email entry view